### PR TITLE
Fix MNIST code to enable saving model to VESSL model registry

### DIFF
--- a/mnist/.gitignore
+++ b/mnist/.gitignore
@@ -1,0 +1,2 @@
+vessl-media/
+*.pkl

--- a/mnist/.vesslignore
+++ b/mnist/.vesslignore
@@ -1,0 +1,5 @@
+input/
+output/
+ouptut/checkpoint/
+vessl-media/
+*.pkl

--- a/mnist/keras/main.py
+++ b/mnist/keras/main.py
@@ -83,6 +83,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--save-image", action="store_true", default=False, help="save the images"
     )
+    parser.add_argument(
+        "--vessl-model-repository",
+        type=str,
+        default="",
+        help="Model repository name to save model in VESSL. If not specified, model will not be saved.",
+    )
     args = parser.parse_args()
 
     # hyperparameters

--- a/mnist/pytorch/.gitignore
+++ b/mnist/pytorch/.gitignore
@@ -1,0 +1,4 @@
+input/
+output/
+ouptut/checkpoint/
+vessl-media/

--- a/mnist/pytorch/model.py
+++ b/mnist/pytorch/model.py
@@ -1,3 +1,4 @@
+import argparse
 from io import BytesIO
 
 import numpy as np
@@ -75,10 +76,23 @@ class MyRunner(vessl.RunnerBase):
         return {"result": data.item()}
 
 
-vessl.configure()
-vessl.register_model(
-    repository_name="model-service-qa",
-    model_number=1,
-    runner_cls=MyRunner,
-    requirements=["torch"],
-)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="PyTorch MNIST Model Register")
+    parser.add_argument("--checkpoint", type=str, default="./output/model.pt", help="checkpoint path")
+    parser.add_argument("--model-repository", type=str, help="Model repository name to save model in VESSL")
+    args = parser.parse_args()
+
+    print("=> Registering trained model to VESSL")
+    model = vessl.create_model(repository_name=args.model_repository)
+    vessl.upload_model_volume_file(
+        repository_name=args.model_repository,
+        model_number=model.number,
+        source_path=args.checkpoint,
+        dest_path="model.pt",
+    )
+    vessl.register_model(
+        repository_name=args.model_repository,
+        model_number=model.number,
+        runner_cls=MyRunner,
+        requirements=["torch==1.13.1"],
+    )

--- a/mnist/pytorch/model.py
+++ b/mnist/pytorch/model.py
@@ -36,7 +36,14 @@ class MyRunner(vessl.RunnerBase):
     @staticmethod
     def load_model(props, artifacts):
         model = Net()
-        model.load_state_dict(torch.load("model.pt"))
+        if torch.backends.mps.is_available():
+            model.load_state_dict(torch.load("model.pt", map_location="mps"))
+        elif torch.cuda.is_available():
+            device = torch.device("cuda")
+            model.load_state_dict(torch.load("model.pt", map_location="cuda:0"))
+            model.to(device)
+        else:
+            model.load_state_dict(torch.load("model.pt", map_location="cpu"))
         model.eval()
         return model
 
@@ -94,5 +101,5 @@ if __name__ == "__main__":
         repository_name=args.model_repository,
         model_number=model.number,
         runner_cls=MyRunner,
-        requirements=["torch==1.13.1"],
+        requirements=["torch<2.0.0"],
     )

--- a/mnist/pytorch/model.py
+++ b/mnist/pytorch/model.py
@@ -36,14 +36,17 @@ class MyRunner(vessl.RunnerBase):
     @staticmethod
     def load_model(props, artifacts):
         model = Net()
-        if torch.backends.mps.is_available():
-            model.load_state_dict(torch.load("model.pt", map_location="mps"))
-        elif torch.cuda.is_available():
+
+        if torch.cuda.is_available():
             device = torch.device("cuda")
-            model.load_state_dict(torch.load("model.pt", map_location="cuda:0"))
+            model.load_state_dict(torch.load("model.pt", map_location=device))
             model.to(device)
+        elif torch.backends.mps.is_available():
+            model.load_state_dict(torch.load("model.pt", map_location="mps"))
         else:
+            device = torch.device('cpu')
             model.load_state_dict(torch.load("model.pt", map_location="cpu"))
+
         model.eval()
         return model
 

--- a/mnist/pytorch/requirements.txt
+++ b/mnist/pytorch/requirements.txt
@@ -1,5 +1,5 @@
 vessl[media]
 numpy
 pandas
-torch
-torchvision
+torch==1.13.1
+torchvision==0.14.1


### PR DESCRIPTION
- VSSL-5983 의 quickstart guide에 사용할 MNIST model을 model registry 로 바로 보낼 수 있게 합니다.
- Legacy Serving 관련 컨텍스트는 삭제합니다.