### PR TITLE
mnist torch version bump

### DIFF
--- a/mnist/pytorch/requirements.txt
+++ b/mnist/pytorch/requirements.txt
@@ -1,5 +1,5 @@
 vessl[media]
 numpy
 pandas
-torch==1.13.1
-torchvision==0.14.1
+torch==2.0.1
+torchvision==0.15.2


### PR DESCRIPTION
python 3.11 지원이 되는 버전으로 bump합니다