### PR TITLE
Modify `hf-chatbot-vllm`

### DIFF
--- a/runs/hf-chatbot-vllm/app.py
+++ b/runs/hf-chatbot-vllm/app.py
@@ -1,11 +1,12 @@
 import argparse
-import os
-from time import sleep
-from typing import List, Optional
-from threading import Thread
+from typing import Optional
 
 import gradio as gr
 from transformers import AutoTokenizer
+from vllm import SamplingParams
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.utils import random_uuid
 
 
 class LLMChatHandler():
@@ -15,8 +16,6 @@ class LLMChatHandler():
             self.tokenizer.eos_token_id,
             self.tokenizer.convert_tokens_to_ids("<|eot_id|>")
         ]
-        from vllm.engine.arg_utils import AsyncEngineArgs
-        from vllm.engine.async_llm_engine import AsyncLLMEngine
 
         def _guess_quantization(model_id) -> Optional[str]:
             if "awq" in model_id or "AWQ" in model_id:
@@ -44,28 +43,10 @@ class LLMChatHandler():
         )
         self.vllm_engine = AsyncLLMEngine.from_engine_args(engine_args)
 
-    def chat_history_to_prompt(self, message: str, history: List[List[str]]) -> str:
-        conversation = []
-        for h in history:
-            user_text, assistant_text = h
-            conversation += [
-                {"role": "user", "content": user_text},
-                {"role": "assistant", "content": assistant_text},
-            ]
-
-        conversation.append({"role": "user", "content": message})
-        prompt = self.tokenizer.apply_chat_template(conversation, tokenize=False, add_generation_prompt=True)
-        return prompt
 
     async def chat_function(self, message, history):
-        prompt = self.chat_history_to_prompt(message, history)
-        response_generator = self.chat_function_vllm(prompt)
-        async for text in response_generator:
-            yield text
-
-    async def chat_function_vllm(self, prompt):
-        from vllm import SamplingParams
-        from vllm.utils import random_uuid
+        history.append({"role": "user", "content": message})
+        prompt = self.tokenizer.apply_chat_template(history, tokenize=False, add_generation_prompt=True)
         sampling_params = SamplingParams(
             stop_token_ids=self.terminators,
             max_tokens=2048,
@@ -80,31 +61,6 @@ class LLMChatHandler():
                     response_txt += output.text
             yield response_txt
 
-    def chat_function_hf(self, prompt):
-        from transformers import pipeline, TextIteratorStreamer
-        streamer = TextIteratorStreamer(self.tokenizer)
-        pipe = pipeline(
-            "text-generation",
-            model=self.hf_model,
-            tokenizer=self.tokenizer,
-            eos_token_id=self.terminators,
-            max_length=2048,
-            temperature=0.6,
-            top_p=0.9,
-            repetition_penalty=1.2,
-            return_full_text=False,
-            streamer=streamer
-        )
-        t = Thread(target=pipe, args=(prompt,))
-        t.start()
-
-        generated_text = ""
-        for new_text in streamer:
-            generated_text += new_text
-            yield generated_text
-
-        t.join()
-
 
 def main(args):
     print(f"Loading the model {args.model_id}...")
@@ -116,7 +72,8 @@ def main(args):
                 f"<h2>Chatbot with 🤗 {args.model_id} 🤗</h2>"
                 "<h3>Interact with LLM using chat interface!<br></h3>"
                 f"<h3>Original model: <a href='https://huggingface.co/{args.model_id}' target='_blank'>{args.model_id}</a></h3>")
-        gr.ChatInterface(hdlr.chat_function)
+        cb = gr.Chatbot(type="messages", scale=20, render_markdown=False)
+        gr.ChatInterface(hdlr.chat_function, chatbot=cb)
 
     demo.queue().launch(server_name="0.0.0.0", server_port=args.port)
 

--- a/runs/hf-chatbot/app.py
+++ b/runs/hf-chatbot/app.py
@@ -111,7 +111,7 @@ def close_app():
 
 def main(args):
     print(f"Loading the model {args.model_id}...")
-    hdlr = LLMChatHandler(args.model_id, args.use_vllm, args.max_model_len, args.tensor_parall_size)
+    hdlr = LLMChatHandler(args.model_id, args.use_vllm, args.max_model_len, args.tensor_parallel_size)
 
     with gr.Blocks(title=f"🤗 Chatbot with {args.model_id}", fill_height=True) as demo:
         with gr.Row():
@@ -138,7 +138,7 @@ if __name__ == "__main__":
     parser.add_argument("--port", default=7860, type=int, help="Port number for the Gradio app.")
     parser.add_argument("--use-vllm", action="store_true", help="Use vLLM instead of HuggingFace AutoModelForCausalLM.")
     parser.add_argument("--max-model-len", type=int, default=0, help="Model context length. If unspecified, will be automatically derived from the model config.")
-    parser.add_argument("--tensor-parallel-size", default=1, type=int, help="Number of tensor parallel replicas.")
+    parser.add_argument("-tp", "--tensor-parallel-size", default=1, type=int, help="Number of tensor parallel replicas.")
     args = parser.parse_args()
 
     main(args)

--- a/runs/hf-chatbot/app.py
+++ b/runs/hf-chatbot/app.py
@@ -8,7 +8,7 @@ import gradio as gr
 from transformers import AutoTokenizer
 
 class LLMChatHandler():
-    def __init__(self, model_id: str, use_vllm: bool = False):
+    def __init__(self, model_id: str, use_vllm: bool = False, max_model_len=0, tensor_parallel_size=1):
         self.use_vllm = use_vllm
         self.tokenizer = AutoTokenizer.from_pretrained(model_id)
         self.terminators = [
@@ -25,6 +25,8 @@ class LLMChatHandler():
                 trust_remote_code=True,
                 quantization="awq" if "awq" in model_id or "AWQ" in model_id else None,
                 dtype="auto",
+                max_model_len=max_model_len if max_model_len else None,
+                tensor_parallel_size=tensor_parallel_size,
             )
             self.vllm_engine = AsyncLLMEngine.from_engine_args(engine_args)
         else:
@@ -109,7 +111,7 @@ def close_app():
 
 def main(args):
     print(f"Loading the model {args.model_id}...")
-    hdlr = LLMChatHandler(args.model_id, args.use_vllm)
+    hdlr = LLMChatHandler(args.model_id, args.use_vllm, args.max_model_len, args.tensor_parall_size)
 
     with gr.Blocks(title=f"🤗 Chatbot with {args.model_id}", fill_height=True) as demo:
         with gr.Row():
@@ -135,7 +137,8 @@ if __name__ == "__main__":
     parser.add_argument("--model-id", default="casperhansen/llama-3-8b-instruct-awq", help="HuggingFace model name for LLM.")
     parser.add_argument("--port", default=7860, type=int, help="Port number for the Gradio app.")
     parser.add_argument("--use-vllm", action="store_true", help="Use vLLM instead of HuggingFace AutoModelForCausalLM.")
-    parser.add_argument("--tensor-parallelism", default=1, type=int, help="Number of tensor parallelism.")
+    parser.add_argument("--max-model-len", type=int, default=0, help="Model context length. If unspecified, will be automatically derived from the model config.")
+    parser.add_argument("--tensor-parallel-size", default=1, type=int, help="Number of tensor parallel replicas.")
     args = parser.parse_args()
 
     main(args)

--- a/runs/hf-chatbot/app.py
+++ b/runs/hf-chatbot/app.py
@@ -8,7 +8,7 @@ import gradio as gr
 from transformers import AutoTokenizer
 
 class LLMChatHandler():
-    def __init__(self, model_id: str, use_vllm: bool = False, max_model_len=0, tensor_parallel_size=1):
+    def __init__(self, model_id: str, use_vllm: bool = False):
         self.use_vllm = use_vllm
         self.tokenizer = AutoTokenizer.from_pretrained(model_id)
         self.terminators = [
@@ -25,8 +25,6 @@ class LLMChatHandler():
                 trust_remote_code=True,
                 quantization="awq" if "awq" in model_id or "AWQ" in model_id else None,
                 dtype="auto",
-                max_model_len=max_model_len if max_model_len else None,
-                tensor_parallel_size=tensor_parallel_size,
             )
             self.vllm_engine = AsyncLLMEngine.from_engine_args(engine_args)
         else:
@@ -111,7 +109,7 @@ def close_app():
 
 def main(args):
     print(f"Loading the model {args.model_id}...")
-    hdlr = LLMChatHandler(args.model_id, args.use_vllm, args.max_model_len, args.tensor_parall_size)
+    hdlr = LLMChatHandler(args.model_id, args.use_vllm)
 
     with gr.Blocks(title=f"🤗 Chatbot with {args.model_id}", fill_height=True) as demo:
         with gr.Row():
@@ -137,8 +135,7 @@ if __name__ == "__main__":
     parser.add_argument("--model-id", default="casperhansen/llama-3-8b-instruct-awq", help="HuggingFace model name for LLM.")
     parser.add_argument("--port", default=7860, type=int, help="Port number for the Gradio app.")
     parser.add_argument("--use-vllm", action="store_true", help="Use vLLM instead of HuggingFace AutoModelForCausalLM.")
-    parser.add_argument("--max-model-len", type=int, default=0, help="Model context length. If unspecified, will be automatically derived from the model config.")
-    parser.add_argument("--tensor-parallel-size", default=1, type=int, help="Number of tensor parallel replicas.")
+    parser.add_argument("--tensor-parallelism", default=1, type=int, help="Number of tensor parallelism.")
     args = parser.parse_args()
 
     main(args)

--- a/runs/hf-chatbot/app.py
+++ b/runs/hf-chatbot/app.py
@@ -111,7 +111,7 @@ def close_app():
 
 def main(args):
     print(f"Loading the model {args.model_id}...")
-    hdlr = LLMChatHandler(args.model_id, args.use_vllm, args.max_model_len, args.tensor_parallel_size)
+    hdlr = LLMChatHandler(args.model_id, args.use_vllm, args.max_model_len, args.tensor_parall_size)
 
     with gr.Blocks(title=f"🤗 Chatbot with {args.model_id}", fill_height=True) as demo:
         with gr.Row():
@@ -138,7 +138,7 @@ if __name__ == "__main__":
     parser.add_argument("--port", default=7860, type=int, help="Port number for the Gradio app.")
     parser.add_argument("--use-vllm", action="store_true", help="Use vLLM instead of HuggingFace AutoModelForCausalLM.")
     parser.add_argument("--max-model-len", type=int, default=0, help="Model context length. If unspecified, will be automatically derived from the model config.")
-    parser.add_argument("-tp", "--tensor-parallel-size", default=1, type=int, help="Number of tensor parallel replicas.")
+    parser.add_argument("--tensor-parallel-size", default=1, type=int, help="Number of tensor parallel replicas.")
     args = parser.parse_args()
 
     main(args)


### PR DESCRIPTION
1. 안 쓰는 import와 함수를 삭제했습니다.
2. `gr.Chatbot`의 타입 중 `tuple`이 deprecate됨에 따라 타입을 `message`로 변경하고, 그에 맞게 `chat_function` 메소드의 로직을 변경했습니다.
3. 현재 Gradio가 `DeepSeek-R1`의 `<think>` 태그를 제대로 핸들하지 못하는 [이슈](https://github.com/gradio-app/gradio/issues/10454) 가 있어, 부득이하게 챗봇 옵션 중 `render_markdown`을 해제했습니다.
    그 결과 챗봇 사용 시 마크다운이 제대로 적용되지 않습니다.
    이 부분은 Gradio 업데이트로 이슈가 해결되면 다시 되돌릴 예정입니다.